### PR TITLE
Add defaultVPC config parameter per account

### DIFF
--- a/api/handlers_managedinstances.go
+++ b/api/handlers_managedinstances.go
@@ -157,7 +157,7 @@ func (s *server) ManagedInstanceCreateHandler(w http.ResponseWriter, r *http.Req
 	}
 
 	// use the DefaultVPC if VpcID is not passed
-	if req.Compute.VpcID == nil && miService.DefaultVPC != "" {
+	if req.Compute != nil && req.Compute.VpcID == nil && miService.DefaultVPC != "" {
 		req.Compute.VpcID = &miService.DefaultVPC
 	}
 

--- a/api/handlers_managedinstances.go
+++ b/api/handlers_managedinstances.go
@@ -156,6 +156,11 @@ func (s *server) ManagedInstanceCreateHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	// use the DefaultVPC if VpcID is not passed
+	if *req.Compute.VpcID == "" {
+		req.Compute.VpcID = &miService.DefaultVPC
+	}
+
 	output, err := miService.CreateAWSManagedInstance(r.Context(), &req)
 	if err != nil {
 		handleError(w, err)

--- a/api/handlers_managedinstances.go
+++ b/api/handlers_managedinstances.go
@@ -157,7 +157,7 @@ func (s *server) ManagedInstanceCreateHandler(w http.ResponseWriter, r *http.Req
 	}
 
 	// use the DefaultVPC if VpcID is not passed
-	if *req.Compute.VpcID == "" {
+	if req.Compute.VpcID == nil && miService.DefaultVPC != "" {
 		req.Compute.VpcID = &miService.DefaultVPC
 	}
 

--- a/common/config.go
+++ b/common/config.go
@@ -20,10 +20,11 @@ type Config struct {
 
 // Account is the configuration for an individual account
 type Account struct {
-	Endpoint string
-	Region   string
-	Id       string
-	Token    string
+	Endpoint   string
+	Region     string
+	Id         string
+	Token      string
+	DefaultVPC string
 }
 
 // Version carries around the API version information

--- a/common/config_test.go
+++ b/common/config_test.go
@@ -10,16 +10,17 @@ var testConfig = []byte(
 	`{
 		"listenAddress": ":8000",
 		"accounts": {
-		  "provider1": {
-			"region": "us-east-1",
-			"akid": "key1",
-			"secret": "secret1"
-		  },
-		  "provider2": {
-			"region": "us-west-1",
-			"akid": "key2",
-			"secret": "secret2"
-		  }
+			"provider1": {
+				"region": "us-east-1",
+				"id": "key1",
+				"token": "secret1",
+				"defaultVPC": "vpc-123"
+			},
+			"provider2": {
+				"region": "us-west-1",
+				"id": "key2",
+				"token": "secret2"
+			}
 		},
 		"token": "SEKRET",
 		"logLevel": "info",
@@ -32,11 +33,16 @@ func TestReadConfig(t *testing.T) {
 	expectedConfig := Config{
 		ListenAddress: ":8000",
 		Accounts: map[string]Account{
-			"provider1": Account{
-				Region: "us-east-1",
+			"provider1": {
+				Region:     "us-east-1",
+				Id:         "key1",
+				Token:      "secret1",
+				DefaultVPC: "vpc-123",
 			},
-			"provider2": Account{
+			"provider2": {
 				Region: "us-west-1",
+				Id:     "key2",
+				Token:  "secret2",
 			},
 		},
 		Token:    "SEKRET",

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -4,7 +4,8 @@
     "someaccount": {
       "region": "us-east-1",
       "id": "spot_account_id",
-      "token": "spot_token"
+      "token": "spot_token",
+      "defaultVPC": "vpc-1234567890"
     }
   },
   "token": "xxxxxx",

--- a/docker/config.deco.json
+++ b/docker/config.deco.json
@@ -4,17 +4,20 @@
     "sandbox": {
       "region": "us-east-1",
       "id": "{{ .sandbox_account_id }}",
-      "token": "{{ .sandbox_token }}"
+      "token": "{{ .sandbox_token }}",
+      "defaultVPC": "{{ .sandbox_default_vpc }}"
     },
     "spinup": {
       "region": "us-east-1",
       "id": "{{ .spinup_account_id }}",
-      "token": "{{ .spinup_token }}"
+      "token": "{{ .spinup_token }}",
+      "defaultVPC": "{{ .spinup_default_vpc }}"
     },
     "spinupsec": {
       "region": "us-east-1",
       "id": "{{ .spinupsec_account_id }}",
-      "token": "{{ .spinupsec_token }}"
+      "token": "{{ .spinupsec_token }}",
+      "defaultVPC": "{{ .spinupsec_default_vpc }}"
     }
   },
   "token": "{{ .api_token }}",

--- a/spotinst/spotinst.go
+++ b/spotinst/spotinst.go
@@ -17,7 +17,8 @@ type Elastigroup struct {
 
 // ManagedInstance is a wrapper around the spotinst managedinstance service and the provider type (eg. aws, azure, gcp, etc)
 type ManagedInstance struct {
-	Service managedinstance.Service
+	Service    managedinstance.Service
+	DefaultVPC string
 }
 
 // NewElastigroupSession creates a new elastigroup session
@@ -39,5 +40,6 @@ func NewManagedInstanceSession(account common.Account) ManagedInstance {
 		Credentials: credentials.NewStaticCredentials(account.Token, account.Id),
 	})
 	m.Service = managedinstance.New(sess)
+	m.DefaultVPC = account.DefaultVPC
 	return m
 }


### PR DESCRIPTION
The VPC needs to be specified when creating managed instances and this allows us to have a default in the config, instead of passing it in the request.